### PR TITLE
Fix: Correct JSX syntax error in page.tsx

### DIFF
--- a/CineSync/page.tsx
+++ b/CineSync/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
               <div className="flex gap-4">
                 <input
                   type="text"
-                  placeholder="How are you feeling? (e.g., "I want something cozy and funny")"
+                  placeholder='How are you feeling? (e.g., "I want something cozy and funny")'
                   value={searchInput}
                   onChange={(e) => setSearchInput(e.target.value)}
                   className="flex-1 p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"


### PR DESCRIPTION
The build was failing due to a syntax error in `CineSync/page.tsx`. This was caused by an unescaped double quote inside the `placeholder` attribute of an `<input>` element.

This change corrects the error by using single quotes for the attribute value, which allows the use of double quotes within the string.

Note: I was unable to run tests to verify this change because the repository is missing a `package.json` file, which prevents the installation of any dependencies. The fix is based on a static analysis of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed the search field’s placeholder text so it displays correctly, preserving the intended quotation marks.
  - Resolved a rendering issue that could prevent the placeholder from appearing as expected.
  - Improves clarity and usability when entering search queries.
  - No impact on existing functionality or UI layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->